### PR TITLE
Linux improvements + Flatpak support

### DIFF
--- a/src/qautostart.cpp
+++ b/src/qautostart.cpp
@@ -123,9 +123,9 @@ void Autostart::setAutostart(bool autostart) {
 
         if (file.open(QIODevice::ReadWrite)) {
             QTextStream stream(&file);
-            stream << "[Desktop Entry]" << endl;
-            stream << "Exec=" << appPath() << endl;
-            stream << "Type=Application" << endl;
+            stream << "[Desktop Entry]" << Qt::endl;
+            stream << "Exec=" << appPath() << Qt::endl;
+            stream << "Type=Application" << Qt::endl;
         }
     }
 }

--- a/src/qautostart.cpp
+++ b/src/qautostart.cpp
@@ -144,7 +144,13 @@ void Autostart::setAutostart(bool autostart) {
 }
 
 QString Autostart::appPath() const {
-    return QCoreApplication::applicationFilePath() + " --autostart";
+    QString cmd;
+    if (Autostart::isFlatpak()) {
+        cmd = "flatpak run " + QString::fromUtf8(qgetenv("FLATPAK_ID"));
+    } else {
+        cmd = QCoreApplication::applicationFilePath();
+    }
+    return cmd + " --autostart";
 }
 
 #else
@@ -163,5 +169,10 @@ QString Autostart::appPath() const {
 #endif
 
 QString Autostart::appName() const {
+#if defined(Q_OS_LINUX)
+    if (Autostart::isFlatpak()) {
+        return QString::fromUtf8(qgetenv("FLATPAK_ID"));
+    }
+#endif
     return QCoreApplication::applicationName();
 }

--- a/src/qautostart.h
+++ b/src/qautostart.h
@@ -30,6 +30,9 @@ class Autostart
 public:
     bool isAutostart() const;
     void setAutostart(bool autostart);
+#if defined (Q_OS_LINUX)
+    QString getAutostartDir() const;
+#endif
 
 protected:
     QString appPath() const;

--- a/src/qautostart.h
+++ b/src/qautostart.h
@@ -32,6 +32,7 @@ public:
     void setAutostart(bool autostart);
 #if defined (Q_OS_LINUX)
     QString getAutostartDir() const;
+    bool isFlatpak() const;
 #endif
 
 protected:


### PR DESCRIPTION
Hi! I'm not a C++ programmer at all, so please bear with me if I did something stupid here. 😅 

Anyway, this pull request adds basic support for the [Desktop Application Autostart Specification](https://specifications.freedesktop.org/autostart-spec/autostart-spec-0.5.html#idm45071660440416), which basically tells us to avoid hard-coding the config directory to `~/.config`, and instead tells us to respect the `$XDG_CONFIG_HOME` environment variable (if set by the user). The `~/.config` directory is used as a fallback.

While I was at it, I also fixed some compiler warnings about deprecated declarations:

`warning: ‘QTextStream& QTextStreamFunctions::endl(QTextStream&)’ is deprecated: Use Qt::endl [-Wdeprecated-declarations]`

Last, but not least, I added support for autostarting Flatpak apps (assuming these apps have write permission to `xdg-config/autostart`). Due to the sandbox nature of Flatpak apps, we can't run them like other apps, i.e. by directly running the binary in `$PATH`. Instead, we run `flatpak run <flatpak app id>`.

For example, a non-Flatpak app called `example` would have the following autostart file generated:

`~/.config/autostart/example.desktop`:
```ini
[Desktop Entry]
Exec=example --autostart
Type=Application
```

Now, the same app running via Flatpak, would have this instead:

`~/.config/autostart/com.example.app.desktop`:
```ini
[Desktop Entry]
Exec=flatpak run com.example.app --autostart
Type=Application
```

I did some manual tests with a local Flatpak build I have of the [Notes app](https://github.com/nuttyartist/notes) (which uses your library), and it worked.

Thanks!