### PR TITLE
fix: ensure compatibility with Qt <5.14

### DIFF
--- a/src/qautostart.h
+++ b/src/qautostart.h
@@ -25,6 +25,14 @@
 
 #include <QString>
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+#include <QTextStream>
+
+namespace Qt {
+    using ::endl;
+}
+#endif
+
 class Autostart
 {
 public:


### PR DESCRIPTION
After PR #3, with the replacement of `endl` by `Qt::endl`, compiling the library with Qt 5.14 (and older), would yield errors:

```
/qautostart/src/qautostart.cpp:139: error: ‘endl’ is not a member of ‘Qt’; did you mean ‘endl’?
  139 |             stream << "[Desktop Entry]" << Qt::endl;
      |                                                ^~~~
```

This PR fixes compatibility with older Qt versions (the oldest version I tested was Qt 5.9.5).